### PR TITLE
Suppress train arrival message during event

### DIFF
--- a/TrainStation/TrainStation/ModEntry.cs
+++ b/TrainStation/TrainStation/ModEntry.cs
@@ -372,6 +372,7 @@ namespace TrainStation
         }
         string destinationMessage;
         ICue cue;
+        GameLocation destination;
 
         private void AttemptToWarpBoat(BoatStop stop)
         {
@@ -393,6 +394,8 @@ namespace TrainStation
                 return;
             }
             LocationRequest request = Game1.getLocationRequest(stop.TargetMapName);
+            destination = request.Location;
+            
             request.OnWarp += Request_OnWarp;
             destinationMessage = Helper.Translation.Get("ArrivalMessage", new { DestinationName = stop.TranslatedName });
 
@@ -407,7 +410,10 @@ namespace TrainStation
 
         private void Request_OnWarp()
         {
-            Game1.pauseThenMessage(3000, destinationMessage, false);
+            if (destination.currentEvent == null)
+            {
+                Game1.pauseThenMessage(3000, destinationMessage, false);
+            }
             finishedTrainWarp = true;
         }
 


### PR DESCRIPTION
By request of Lumisteria (aka Lumina), who is a prominent Content Patcher pack creator, I wrote and tested a very small fix here that checks whether an event is going on in the target area between warping and showing the arrival message. It appears to work well and I don't foresee how it would create any issues/unexpected changes. Let me know if you have any questions! Thanks for this cool mod. :)